### PR TITLE
Add a few more constructors/conversions

### DIFF
--- a/src/DoubleDouble.jl
+++ b/src/DoubleDouble.jl
@@ -84,6 +84,8 @@ convert{T<:AbstractFloat}(::Type{Double{T}}, x::Irrational) = convert(Double{T},
 convert(::Type{BigFloat}, x::Single) = big(x.hi)
 convert(::Type{BigFloat}, x::Double) = big(x.hi) + big(x.lo)
 
+convert{T}(::Type{Single{T}}, x::Integer) = convert(Single{T}, T(x))
+convert{T}(::Type{Double{T}}, x::Integer) = convert(Double{T}, T(x))
 
 promote_rule{T<:AbstractFloat}(::Type{Single{T}}, ::Type{T}) = Single{T}
 promote_rule{T<:AbstractFloat}(::Type{Double{T}}, ::Type{T}) = Double{T}
@@ -93,6 +95,7 @@ promote_rule{T<:AbstractFloat}(::Type{Double{T}}, ::Type{Single{T}}) = Double{T}
 promote_rule{s,T<:AbstractFloat}(::Type{Irrational{s}}, ::Type{Single{T}}) = Double{Float64}
 
 
+Single(x::Real) = convert(Single{Float64}, Float64(x))
 
 Double(x::Real) = convert(Double{Float64}, Float64(x))
 Double(x::BigFloat) = convert(Double{Float64}, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,5 +46,16 @@ a = Double(big"3.1")
 @test a == Double(3.1, -8.881784197001253e-17)
 @test BigFloat(a) == big"3.099999999999999999999999999999995069619342368676216176696466982586064542459781"
 
-@test Double(3) == Double(3.0, 0.0)
-@test Double(big(3)) == Double(3.0, 0.0)
+@test Single(3) === Single(3.0)
+@test Double(3) === Double(3.0, 0.0)
+@test Double(big(3)) === Double(3.0, 0.0)
+
+@test convert(Single{Float64}, 1) === Single(1.0)
+@test convert(Single{Float32}, 1) === Single(1.0f0)
+@test convert(Double{Float64}, 1) === Double(1.0, 0.0)
+@test convert(Double{Float32}, 1) === Double(1.0f0, 0.0f0)
+
+@test Single{Float32}(3) === Single{Float32}(3.0f0)
+@test Double{Float32}(3) === Double{Float32}(3.0f0, 0.0f0)
+@test Single{Float32}(BigFloat(3)) === Single{Float32}(3.0f0)
+@test Double{Float32}(BigFloat(3)) === Double{Float32}(3.0f0, 0.0f0)


### PR DESCRIPTION
These are a couple of things I noticed while playing with this package in the course of working on https://github.com/JuliaLang/julia/pull/18777. Mostly I just wanted to say thanks for the package, I learned a lot from it and it was very useful as I played with different strategies.

FYI: if we do need to develop a faster pure-software implementation of `lerpi` that julia PR, then I think the main trick would be a `SplitNumber{T}` type that has already been passed through `splitprec`. Seems like the easiest way to develop that would be here in this package, and then possibly move a subset of the machinery to base. If I go that route, want it?
