### PR TITLE
Add methods for zero and one with tests

### DIFF
--- a/src/DoubleDouble.jl
+++ b/src/DoubleDouble.jl
@@ -5,7 +5,8 @@ import Base:
     convert,
     *, +, -, /, sqrt, <,
     rem, abs, rand, promote_rule,
-    show, big
+    show, big,
+    zero, one
 
 abstract AbstractDouble{T} <: Real
 
@@ -50,6 +51,11 @@ function splitprec(x::AbstractFloat)
     h, x-h
 end
 
+
+zero{T<:AbstractFloat}(::Type{Double{T}}) = Double(zero(T))
+one{T<:AbstractFloat}(::Type{Double{T}}) = Double(one(T))
+zero(a::Double) = Double(zero(a.hi))
+one(a::Double) = Double(one(a.hi))
 
 # ones(T::Double, dims...) = fill!(Array(T, dims...), (one)(T))
 # zeros(T::Double, dims...) = fill!(Array(T, dims...), (zero)(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,11 @@ dy = Double(y)
 @test x == sx == dx
 @test y == sy == dy
 
+@test zero(Double{Float64}) == Double(0.0, 0.0)
+@test one(Double{Float64}) == Double(1.0, 0.0)
+@test zero(Double(0.0, 0.0)) == Double(0.0, 0.0)
+@test one(Double(0.0, 0.0)) == Double(1.0, 0.0)
+
 dxy = dx*dy
 bxy = bx*by
 @test sx*sy == dxy


### PR DESCRIPTION
There is an old issue to make TaylorSeries work with DoubleDouble; see https://github.com/JuliaDiff/TaylorSeries.jl/issues/56. The reason it was not working is because `zero(::Type{Double{T}})` and `one(::Type{Double{T}})` were lacking. I'm simply adding them.